### PR TITLE
Fix logical channel check on MANAGE(CLOSE)

### DIFF
--- a/pygp/gp/gp_functions.py
+++ b/pygp/gp/gp_functions.py
@@ -1721,7 +1721,7 @@ def manage_channel(open_channel, logical_channel):
     if open_channel == True:
         capdu = '00 70 00 00 01'
     else:
-        if logical_channel < 0x01 and logical_channel > 0x03:
+        if logical_channel < 0x01 or logical_channel > 0x03:
             # channel number must be between 01 and 03
             error_status = create_error_status(ERROR_WRONG_DATA, runtimeErrorDict[ERROR_WRONG_DATA])
             return error_status


### PR DESCRIPTION
Hello, please see a small uninportant issue i came across.
I might be misinformed about the logical channel max of 3, as when i look in  ISO/IEC 7816-4 §7.1.2 MANAGE CHANNEL command, it states: "• If P2 is set from '01' to '13', then the channel numbered in P2 shall be closed." So maybe this check should have a max of 0xC ?
Thank you